### PR TITLE
Refactor webhook and dashboard endpoints

### DIFF
--- a/app/routes/dashboard_router.py
+++ b/app/routes/dashboard_router.py
@@ -9,49 +9,60 @@ from app.models import message, contact, inbox
 
 dashboard_route = APIRouter(tags=["Dashboard"])
 
-@dashboard_route.get("/dashboard_info")
-def get_dashboard_info(db: Session = Depends(get_db)):
-    today = datetime.now().date()
+
+def _base_dashboard_data(db: Session, today: datetime.date):
+    """Return basic dashboard metrics used by multiple endpoints."""
     week_ago = today - timedelta(days=7)
     month_ago = today - timedelta(days=30)
 
-    sent_today = db.query(func.count()).filter(
-        message.Message_Type == "Outgoing",
-        func.date(message.datetime) == today
-    ).scalar()
-    sent_week = db.query(func.count()).filter(
-        message.Message_Type == "Outgoing",
-        func.date(message.datetime) >= week_ago
-    ).scalar()
-    sent_month = db.query(func.count()).filter(
-        message.Message_Type == "Outgoing",
-        func.date(message.datetime) >= month_ago
-    ).scalar()
+    sent_today = (
+        db.query(func.count())
+        .filter(message.Message_Type == "Outgoing", func.date(message.datetime) == today)
+        .scalar()
+    )
+    sent_week = (
+        db.query(func.count())
+        .filter(message.Message_Type == "Outgoing", func.date(message.datetime) >= week_ago)
+        .scalar()
+    )
+    sent_month = (
+        db.query(func.count())
+        .filter(message.Message_Type == "Outgoing", func.date(message.datetime) >= month_ago)
+        .scalar()
+    )
 
-    received_today = db.query(func.count()).filter(
-        message.Message_Type == "Incoming",
-        func.date(message.datetime) == today
-    ).scalar()
-    received_week = db.query(func.count()).filter(
-        message.Message_Type == "Incoming",
-        func.date(message.datetime) >= week_ago
-    ).scalar()
-    received_month = db.query(func.count()).filter(
-        message.Message_Type == "Incoming",
-        func.date(message.datetime) >= month_ago
-    ).scalar()
+    received_today = (
+        db.query(func.count())
+        .filter(message.Message_Type == "Incoming", func.date(message.datetime) == today)
+        .scalar()
+    )
+    received_week = (
+        db.query(func.count())
+        .filter(message.Message_Type == "Incoming", func.date(message.datetime) >= week_ago)
+        .scalar()
+    )
+    received_month = (
+        db.query(func.count())
+        .filter(message.Message_Type == "Incoming", func.date(message.datetime) >= month_ago)
+        .scalar()
+    )
 
     total_active_contacts = db.query(func.count(contact.contactId)).scalar()
-
-    contacts_today = db.query(func.count(func.distinct(message.WhatsappjId))).filter(
-        func.date(message.datetime) == today
-    ).scalar()
-    contacts_week = db.query(func.count(func.distinct(message.WhatsappjId))).filter(
-        func.date(message.datetime) >= week_ago
-    ).scalar()
-    contacts_month = db.query(func.count(func.distinct(message.WhatsappjId))).filter(
-        func.date(message.datetime) >= month_ago
-    ).scalar()
+    contacts_today = (
+        db.query(func.count(func.distinct(message.WhatsappjId)))
+        .filter(func.date(message.datetime) == today)
+        .scalar()
+    )
+    contacts_week = (
+        db.query(func.count(func.distinct(message.WhatsappjId)))
+        .filter(func.date(message.datetime) >= week_ago)
+        .scalar()
+    )
+    contacts_month = (
+        db.query(func.count(func.distinct(message.WhatsappjId)))
+        .filter(func.date(message.datetime) >= month_ago)
+        .scalar()
+    )
 
     total_inboxes = db.query(func.count(inbox.inbox_id)).scalar()
 
@@ -70,56 +81,20 @@ def get_dashboard_info(db: Session = Depends(get_db)):
             "active": total_active_contacts,
             "talked_today": contacts_today,
             "talked_last_7_days": contacts_week,
-            "talked_last_30_days": contacts_month
+            "talked_last_30_days": contacts_month,
         },
-        "total_inboxes": total_inboxes
+        "total_inboxes": total_inboxes,
     }
+
+@dashboard_route.get("/dashboard_info")
+def get_dashboard_info(db: Session = Depends(get_db)):
+    today = datetime.now().date()
+    return _base_dashboard_data(db, today)
 
 @dashboard_route.get("/dashboard_time")
 def get_dashboard_time(db: Session = Depends(get_db)):
     today = datetime.now().date()
-    week_ago = today - timedelta(days=7)
-    month_ago = today - timedelta(days=30)
-
-    sent_today = db.query(func.count()).filter(
-        message.Message_Type == "Outgoing",
-        func.date(message.datetime) == today
-    ).scalar()
-    sent_week = db.query(func.count()).filter(
-        message.Message_Type == "Outgoing",
-        func.date(message.datetime) >= week_ago
-    ).scalar()
-    sent_month = db.query(func.count()).filter(
-        message.Message_Type == "Outgoing",
-        func.date(message.datetime) >= month_ago
-    ).scalar()
-
-    received_today = db.query(func.count()).filter(
-        message.Message_Type == "Incoming",
-        func.date(message.datetime) == today
-    ).scalar()
-    received_week = db.query(func.count()).filter(
-        message.Message_Type == "Incoming",
-        func.date(message.datetime) >= week_ago
-    ).scalar()
-    received_month = db.query(func.count()).filter(
-        message.Message_Type == "Incoming",
-        func.date(message.datetime) >= month_ago
-    ).scalar()
-
-    total_active_contacts = db.query(func.count(contact.contactId)).scalar()
-
-    contacts_today = db.query(func.count(func.distinct(message.WhatsappjId))).filter(
-        func.date(message.datetime) == today
-    ).scalar()
-    contacts_week = db.query(func.count(func.distinct(message.WhatsappjId))).filter(
-        func.date(message.datetime) >= week_ago
-    ).scalar()
-    contacts_month = db.query(func.count(func.distinct(message.WhatsappjId))).filter(
-        func.date(message.datetime) >= month_ago
-    ).scalar()
-
-    total_inboxes = db.query(func.count(inbox.inbox_id)).scalar()
+    base_data = _base_dashboard_data(db, today)
 
     sent_by_hour_query = db.query(
         extract('hour', message.datetime).label('hour'),
@@ -141,24 +116,6 @@ def get_dashboard_time(db: Session = Depends(get_db)):
     received_by_hour = {f"time_{int(h)}": c for h, c in received_by_hour_query}
     received_by_time = [{f"time_{h}": received_by_hour.get(f"time_{h}", 0)} for h in range(24)]
 
-    return {
-        "messages_sent": {
-            "today": sent_today,
-            "last_7_days": sent_week,
-            "last_30_days": sent_month,
-            "sent_by_time": sent_by_time
-        },
-        "messages_received": {
-            "today": received_today,
-            "last_7_days": received_week,
-            "last_30_days": received_month,
-            "received_by_time": received_by_time
-        },
-        "contacts": {
-            "active": total_active_contacts,
-            "talked_today": contacts_today,
-            "talked_last_7_days": contacts_week,
-            "talked_last_30_days": contacts_month
-        },
-        "total_inboxes": total_inboxes
-    }
+    base_data["messages_sent"]["sent_by_time"] = sent_by_time
+    base_data["messages_received"]["received_by_time"] = received_by_time
+    return base_data


### PR DESCRIPTION
## Summary
- refactor webhook logic into helper functions
- factor out repeated dashboard queries
- keep routes small and clear

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68636c79779c8326bb631474290f5356